### PR TITLE
Removing short open tag

### DIFF
--- a/src/Fomo/FomoClient.php
+++ b/src/Fomo/FomoClient.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * Copyright (c) 2016. Fomo. https://www.usefomo.com
  **/


### PR DESCRIPTION
Short open tags are disabled default on some Ubuntu distos. Also it's usually used for backward compatibility reasons.
