### PR TITLE
composer fixes before switching to curl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 *.iml
+vendor/**

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,19 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "dfa4669ac0e8d4f9c3d2fa00220a9ced",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.0"
+    },
+    "platform-dev": []
+}

--- a/example/fomo-example.php
+++ b/example/fomo-example.php
@@ -1,12 +1,23 @@
 <?php
+
+$loader = include 'vendor/autoload.php';
+$loader->add('Fomo\Fomo', __DIR__.'/src');
+
+// activate the autoloader
+$loader->register();
+
 use Fomo\FomoClient;
 use Fomo\FomoEventBasic;
 use Fomo\FomoEventsWithMeta;
 
-include_once '../src/Fomo/FomoClient.php';
-include_once '../src/Fomo/FomoEventBasic.php';
-include_once '../src/Fomo/FomoEventsWithMeta.php';
-$token = '<token>';
+$token = getenv( 'FOMO_TOKEN' );
+
+if ( !$token )
+{
+    echo PHP_EOL . PHP_EOL . "Please setup the env variable FOMO_TOKEN=<YOUR_FOMO_TOKEN_HERE>". PHP_EOL . PHP_EOL;
+    exit( 1 );
+}
+
 $client = new FomoClient($token);
 // $client->setProxy('tcp://127.0.0.1:8888');
 

--- a/src/Fomo/FomoClient.php
+++ b/src/Fomo/FomoClient.php
@@ -5,9 +5,6 @@
 
 namespace Fomo;
 
-include_once 'FomoEvent.php';
-include_once 'FomoDeleteMessageResponse.php';
-
 /**
  * Fomo Client is wrapper around official Fomo API
  *

--- a/src/Fomo/FomoEvent.php
+++ b/src/Fomo/FomoEvent.php
@@ -1,8 +1,6 @@
 <?php
 namespace Fomo;
 
-include_once 'FomoEventBasic.php';
-
 /**
  * Class FomoEvent
  * @package Fomo

--- a/src/Fomo/FomoEventBasic.php
+++ b/src/Fomo/FomoEventBasic.php
@@ -1,8 +1,6 @@
 <?php
 namespace Fomo;
 
-include_once 'FomoEventCustomAttribute.php';
-
 /**
  * Class FomoEventBasic
  * @package Fomo

--- a/src/Fomo/FomoEventsWithMeta.php
+++ b/src/Fomo/FomoEventsWithMeta.php
@@ -1,9 +1,6 @@
 <?php
 namespace Fomo;
 
-include_once 'FomoEvent.php';
-include_once 'FomoEventsMeta.php';
-
 /**
  * Class FomoEventsWithMeta
  * @package Fomo


### PR DESCRIPTION
This patch takes care of two composer related things:
- autoloading all the FOMO namespace classes
- excluding the vendor folder using .gitignore

Author: Vladimir Ghetau