### PR TITLE
Improve security by verifying certificates

### DIFF
--- a/src/Fomo/FomoClient.php
+++ b/src/Fomo/FomoClient.php
@@ -162,8 +162,8 @@ class FomoClient
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
         curl_setopt($curl, CURLOPT_HEADER, true);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
         // curl_setopt($curl, CURLOPT_VERBOSE, TRUE);
         curl_setopt($curl, CURLOPT_HTTPHEADER, array(


### PR DESCRIPTION
The client used insecure curl settings which shouldn’t be used in production:

CURLOPT_SSL_VERIFYPEER: was enabled to ensure the server’s certificate
is verified by curl
CURLOPT_SSL_VERIFYHOST: set to 2 to check the existence of a common name
(CN) and also verify that it matches the hostname provided