### PR TITLE
Throw exception instead of printing error message and terminating the script

### DIFF
--- a/src/Fomo/Exception/ApiException.php
+++ b/src/Fomo/Exception/ApiException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Fomo\Exception;
+
+class ApiException extends \RuntimeException
+{
+
+}


### PR DESCRIPTION
In case of an error with Fomo’s API it was impossible to handle the
situation gracefully as the application was terminated by calling
`exit()`. Printing an error message to a potentially user-facing
client is a bad idea, too. This commit changes that behaviour by
throwing exceptions which can be catched by the caller.