### PR TITLE
Autoloading optimizations; code style improvements; fix 'Array to string conversion'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,15 +34,6 @@
   "autoload": {
     "psr-4": {
       "Fomo\\": "src/Fomo"
-    },
-    "classmap": [
-      "src/Fomo/FomoClient.php",
-      "src/Fomo/FomoDeleteMessageResponse.php",
-      "src/Fomo/FomoEvent.php",
-      "src/Fomo/FomoEventBasic.php",
-      "src/Fomo/FomoEventCustomAttribute.php",
-      "src/Fomo/FomoEventsMeta.php",
-      "src/Fomo/FomoEventsWithMeta.php"
-    ]
+    }
   }
 }

--- a/example/fomo-example-autoload.php
+++ b/example/fomo-example-autoload.php
@@ -1,28 +1,25 @@
 <?php
 
-$loader = include 'vendor/autoload.php';
-$loader->add('Fomo\Fomo', __DIR__.'/src');
-
-// activate the autoloader
-$loader->register();
+require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 $token = getenv('FOMO_TOKEN');
 
-if (!$token) {
-    echo PHP_EOL . PHP_EOL . "Please setup the env variable FOMO_TOKEN=<YOUR_FOMO_TOKEN_HERE>". PHP_EOL . PHP_EOL;
+if (! $token) {
+    echo PHP_EOL . PHP_EOL . 'Please setup the env variable FOMO_TOKEN=<YOUR_FOMO_TOKEN_HERE>' . PHP_EOL . PHP_EOL;
     exit(1);
 }
 
 function showEventObject($fomoEvent, $method)
 {
     echo PHP_EOL,
-        ($method ? "{$method} Event Object Type: " : "")
-        , get_class($fomoEvent), PHP_EOL;
-    echo "Methods:", PHP_EOL;
-    
-    foreach (get_object_vars($fomoEvent) as $name=>$var) {
-        echo " - {$name}={$var}", PHP_EOL;
+    ($method ? "{$method} Event Object Type: " : ''),
+    get_class($fomoEvent), PHP_EOL;
+
+    echo 'Methods:', PHP_EOL;
+
+    foreach (get_object_vars($fomoEvent) as $name => $var) {
+        printf(' - %s=%s%s', $name, print_r($var, true), PHP_EOL);
     }
-    
+
     echo PHP_EOL;
 }


### PR DESCRIPTION
- remove classmap from composer.json, as it’s redundant with the
  PSR-4 autoloader-config
- include autoloader in example code as described in
  https://getcomposer.org/doc/01-basic-usage.md#autoloading
- code style improvements in example code
- fix ‘Array to string conversion’ in example code function
  `showEventObject()`