### PR TITLE
Remove `curl/curl` dependency as it’s not used anywhere

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   "minimum-stability": "stable",
   "require": {
     "php": ">=5.3.0",
-    "curl/curl": "^1.6"
+    "ext-curl": "*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
`curl/curl` is an OO wrapper fur PHP’s curl extension. It can be safely
removed as dependeny it’s nowhere used in the UseFomo PHP SDK.

I’ve added `ext-curl` as an requirement instead as this PHP extension
is actually used in the library.