### PR TITLE
Remove the version number from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "usefomo/fomo-php-sdk",
   "description": "Fomo PHP SDK is the official SDK wrapper for the Fomo API service",
-  "version": "1.0.8",
   "keywords": [
     "fomo",
     "notifications",


### PR DESCRIPTION
Specifying the version number in composer.json can and will lead to
confusion.

Citing the [Composer schema documentation](https://getcomposer.org/doc/04-schema.md#version):

> In most cases this is not required and should be omitted

> if the package repository can infer the version from somewhere,
> such as the VCS tag name in the VCS repository.
> In that case it is also recommended to omit it.

> Packagist uses VCS repositories, so the statement above is very much
> true for Packagist as well. Specifying the version yourself will most
> likely end up creating problems at some point due to human error.